### PR TITLE
Add directives to build with osx

### DIFF
--- a/dub.sdl
+++ b/dub.sdl
@@ -6,6 +6,7 @@ license "BSL-1.0"
 targetPath "build"
 
 // Link pre-compiled libs, awaiting ImportC improvements
+sourceFiles "lib/libc-parser.a" "lib/libtree-sitter.a" platform="osx"
 sourceFiles "lib/libc-parser.a" "lib/libtree-sitter.a" platform="linux"
 sourceFiles "lib/libc-parser.obj" "lib/libtree-sitter.obj" platform="windows"
 workingDirectory "build"

--- a/makefile
+++ b/makefile
@@ -13,7 +13,7 @@ all: build-lib
 
 .PHONY: build-lib
 build-lib:
-	clang -E -P source/ctod/c_parser.c > source/ctod/c_parser_pre.c
+	clang -E -Isource -P source/ctod/c_parser.c > source/ctod/c_parser_pre.c
 	$(CC) -c -Isource source/ctod/c_parser.c -o lib/libc-parser$(TARGET_EXT) -O2 -fPIC
 
 # $(CC) -Isource source/main.c lib/libc-parser.a lib/libtree-sitter$(TARGET_EXT) -o build/parser -O2


### PR DESCRIPTION
Merging in your changes is cumbersome when these conflict. This shouldn't harm existing code.

Note that having the binary tree-sitter lib checked in is problematic. I can push an osx-specific version, but it's only for arm, so I'm not sure what the right move is. Dub really doesn't have a good story for shipping binary libs.